### PR TITLE
fix: update telegramGroupId for Demo Sismo Builders

### DIFF
--- a/space-config/sismo/index.ts
+++ b/space-config/sismo/index.ts
@@ -67,7 +67,7 @@ export const sismoConfig: SpaceConfig = {
       telegramInviteLink: "https://t.me/+3uFRdr5FhjkwM2Zk",
       demo: {
         appId: "0xd21d9ab6eaf8bcc16eff8d9a76764eab",
-        telegramGroupId: "-738751449",
+        telegramGroupId: "-1001658867707",
         telegramInviteLink: "https://t.me/+MJxmxpCwKg82M2I0",
         impersonateAddresses: [
           "telegram:dhadrien:1234",

--- a/src/app/api/zk-telegram-bot/webhook/route.ts
+++ b/src/app/api/zk-telegram-bot/webhook/route.ts
@@ -74,6 +74,7 @@ const approve = async (request: JoinRequest): Promise<void> => {
   const approveURL = new URL(`https://api.telegram.org/bot${env.telegramBotToken}/approveChatJoinRequest`);
   approveURL.searchParams.append("chat_id", request.groupId);
   approveURL.searchParams.append("user_id", request.userId);
+  if (env.isDev) { console.info(approveURL.toString()); }
   await axios.get(approveURL.toString());
 }
 
@@ -81,6 +82,7 @@ const decline = async (request: JoinRequest): Promise<void> => {
   const declineURL = new URL(`https://api.telegram.org/bot${env.telegramBotToken}/declineChatJoinRequest`);
   declineURL.searchParams.append("chat_id", request.groupId);
   declineURL.searchParams.append("user_id", request.userId);
+  if (env.isDev) { console.info(declineURL.toString()); }
   await axios.get(declineURL.toString());
 }
 


### PR DESCRIPTION
The telegram group was promoted to super group and had an id change when the second bot was added 
https://stackoverflow.com/questions/55821394/can-chat-ids-of-telegram-bots-be-changed